### PR TITLE
PDE-1318: changes to POJO extending flex trial org support

### DIFF
--- a/model_baselines.go
+++ b/model_baselines.go
@@ -1,7 +1,7 @@
 /*
 Sumo Logic Organizations Management API
 
-Welcome to the Sumo Logic's API Reference for Organizations Management. You can use these APIs to interact with the Sumo Logic platform to manage accounts and subscription. Refer to [API Authentication](https://help.sumologic.com/APIs/General-API-Information/API-Authentication) for more information about authentication. You can also look at [other APIs](https://help.sumologic.com/APIs) for more information about some other API endpoints. 
+Welcome to the Sumo Logic's API Reference for Organizations Management. You can use these APIs to interact with the Sumo Logic platform to manage accounts and subscription. Refer to [API Authentication](https://help.sumologic.com/APIs/General-API-Information/API-Authentication) for more information about authentication. You can also look at [other APIs](https://help.sumologic.com/APIs) for more information about some other API endpoints.
 
 API version: 1.0.0
 */
@@ -30,10 +30,14 @@ type Baselines struct {
 	// The average daily amount of tracing data this child org is expected to ingest, in GB. This is currently not available for all customers. It will be enabled only if available for your organization. Please contact your Sumo Logic account team to learn more.
 	TracingIngest *int64 `json:"tracingIngest,omitempty"`
 	// The average daily amount of cse data this child org is expected to ingest, in GB.  This is currently not available for all customers. It will be enabled only if available for your organization. Please contact your Sumo Logic account team to learn more.
-	CseIngest *int64 `json:"cseIngest,omitempty"`
+	CseIngest         *int64             `json:"cseIngest,omitempty"`
 	FeatureActivation *FeatureActivation `json:"featureActivation,omitempty"`
 	// Total number of credits to be allocated to the child organization. This field is applicable only in CREATE a new organization and UPDATE an organization requests.
 	TotalCreditsAllocated *int64 `json:"totalCreditsAllocated,omitempty"`
+	// Only applicable for Flex orgs
+	FlexIngest    *int64 `json:"flexIngest,omitempty"`
+	FlexStorage   *int64 `json:"flexStorage,omitempty"`
+	FlexScanRatio *int64 `json:"flexScanRatio,omitempty"`
 }
 
 // NewBaselines instantiates a new Baselines object
@@ -334,7 +338,7 @@ func (o *Baselines) SetTotalCreditsAllocated(v int64) {
 }
 
 func (o Baselines) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -405,5 +409,3 @@ func (v *NullableBaselines) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/model_baselines.go
+++ b/model_baselines.go
@@ -30,7 +30,7 @@ type Baselines struct {
 	// The average daily amount of tracing data this child org is expected to ingest, in GB. This is currently not available for all customers. It will be enabled only if available for your organization. Please contact your Sumo Logic account team to learn more.
 	TracingIngest *int64 `json:"tracingIngest,omitempty"`
 	// The average daily amount of cse data this child org is expected to ingest, in GB.  This is currently not available for all customers. It will be enabled only if available for your organization. Please contact your Sumo Logic account team to learn more.
-	CseIngest         *int64             `json:"cseIngest,omitempty"`
+	CseIngest *int64 `json:"cseIngest,omitempty"`
 	FeatureActivation *FeatureActivation `json:"featureActivation,omitempty"`
 	// Total number of credits to be allocated to the child organization. This field is applicable only in CREATE a new organization and UPDATE an organization requests.
 	TotalCreditsAllocated *int64 `json:"totalCreditsAllocated,omitempty"`

--- a/model_read_organization_response.go
+++ b/model_read_organization_response.go
@@ -28,7 +28,7 @@ type ReadOrganizationResponse struct {
 	// First name of the account owner.
 	FirstName string `json:"firstName"`
 	// Last name of the account owner.
-	LastName     *string             `json:"lastName,omitempty"`
+	LastName *string `json:"lastName,omitempty"`
 	Subscription CreditsSubscription `json:"subscription"`
 	// The unique identifier of an organization. It consists of the deployment ID and the hexadecimal account ID separated by a dash `-` character.
 	OrgId string `json:"orgId"`
@@ -290,7 +290,7 @@ func (o *ReadOrganizationResponse) UnmarshalJSON(data []byte) (err error) {
 		return err
 	}
 
-	for _, requiredProperty := range requiredProperties {
+	for _, requiredProperty := range(requiredProperties) {
 		if _, exists := allProperties[requiredProperty]; !exists {
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}

--- a/model_read_organization_response.go
+++ b/model_read_organization_response.go
@@ -1,7 +1,7 @@
 /*
 Sumo Logic Organizations Management API
 
-Welcome to the Sumo Logic's API Reference for Organizations Management. You can use these APIs to interact with the Sumo Logic platform to manage accounts and subscription. Refer to [API Authentication](https://help.sumologic.com/APIs/General-API-Information/API-Authentication) for more information about authentication. You can also look at [other APIs](https://help.sumologic.com/APIs) for more information about some other API endpoints. 
+Welcome to the Sumo Logic's API Reference for Organizations Management. You can use these APIs to interact with the Sumo Logic platform to manage accounts and subscription. Refer to [API Authentication](https://help.sumologic.com/APIs/General-API-Information/API-Authentication) for more information about authentication. You can also look at [other APIs](https://help.sumologic.com/APIs) for more information about some other API endpoints.
 
 API version: 1.0.0
 */
@@ -11,8 +11,8 @@ API version: 1.0.0
 package openapi
 
 import (
-	"encoding/json"
 	"bytes"
+	"encoding/json"
 	"fmt"
 )
 
@@ -28,12 +28,14 @@ type ReadOrganizationResponse struct {
 	// First name of the account owner.
 	FirstName string `json:"firstName"`
 	// Last name of the account owner.
-	LastName *string `json:"lastName,omitempty"`
+	LastName     *string             `json:"lastName,omitempty"`
 	Subscription CreditsSubscription `json:"subscription"`
 	// The unique identifier of an organization. It consists of the deployment ID and the hexadecimal account ID separated by a dash `-` character.
 	OrgId string `json:"orgId"`
 	// Identifier of the deployment in which the organization is present.
 	DeploymentId *string `json:"deploymentId,omitempty" validate:"regexp=^(mb|stag|long|prod|us2|dub|syd|mum|fra|tky|mon|fed|au|ca|de|eu|in|jp|us1)$"`
+	// Only applicable for flex orgs
+	IsSSOSetup bool `json:"isSSOSetup"`
 }
 
 type _ReadOrganizationResponse ReadOrganizationResponse
@@ -245,7 +247,7 @@ func (o *ReadOrganizationResponse) SetDeploymentId(v string) {
 }
 
 func (o ReadOrganizationResponse) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -285,10 +287,10 @@ func (o *ReadOrganizationResponse) UnmarshalJSON(data []byte) (err error) {
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
-		return err;
+		return err
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
+	for _, requiredProperty := range requiredProperties {
 		if _, exists := allProperties[requiredProperty]; !exists {
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
@@ -344,5 +346,3 @@ func (v *NullableReadOrganizationResponse) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-


### PR DESCRIPTION
Added few extra fields which are only applicable to flex tier orgs and are needed when we map the api results with POJO in List Orgnizations api.